### PR TITLE
Top Bar PFP

### DIFF
--- a/devDownloads/roblox2016-preLatest.user.css
+++ b/devDownloads/roblox2016-preLatest.user.css
@@ -3704,4 +3704,8 @@
     #populated-complimentary-items-recommendations {
         display: none;
     }
+    /* top bar pfp */      
+#navigation .text-nav.dynamic-overflow-container > .avatar-headshot-xs.avatar > .avatar-card-image.thumbnail-2d-container, #navigation .text-nav.dynamic-overflow-container > .avatar-headshot-xs.avatar {
+    display: none !important;
+}
 }


### PR DESCRIPTION
Gets rid of the user icon next to your name in the menu bar (the one with home, profile, etc.) to be more accurate to 2016