### PR TITLE
Add creditVis option and fix credit icon on dark mode

### DIFF
--- a/devDownloads/roblox2016-preLatest.user.css
+++ b/devDownloads/roblox2016-preLatest.user.css
@@ -7,6 +7,7 @@
 @license        MIT License
 @var select profileVis 'Hide profile in nav bar?' ['block:Visible', 'none:Hidden']
 @var select displayRecommended 'displayRecommended' ['block:Visible', 'none:Hidden']
+@var select creditVis 'Hide credit on nav bar?' ['block:Visible', 'none:Hidden']
 ==/UserStyle== */
 @-moz-document domain("web.roblox.com"), domain("www.roblox.com") {
 /* Hey! if you see this, check out the Github repository for this!
@@ -620,6 +621,11 @@
     }
     /*robux patch      */
     /* Some moved to image patch section */
+
+    /* Remove nav-credit display */
+    .nav-credit {
+        display: var(--creditVis) !important;
+    }
 
     .light-theme .icon-default-economy-28x28, .light-theme .icon-robux-28x28, .light-theme .icon-robux-gold-28x28, .light-theme .icon-robux-white {
     /*     background-image: url(https://svgur.com/i/GuZ.svg); */

--- a/devDownloads/roblox2016-preLatest.user.css
+++ b/devDownloads/roblox2016-preLatest.user.css
@@ -3706,7 +3706,7 @@
     .dark-theme #autocomplete-list {
         background: rgba(35, 37, 39, .81);
     }
-    #nav-credit-icon {
+    .light-theme #nav-credit-icon {
         filter: invert(1);
     }
     /* New games interface patch : 001  */

--- a/stylustheme.css
+++ b/stylustheme.css
@@ -3695,7 +3695,7 @@
     .dark-theme #autocomplete-list {
         background: rgba(35, 37, 39, .81);
     }
-    #nav-credit-icon {
+    .light-theme #nav-credit-icon {
         filter: invert(1);
     }
     /* New games interface patch : 001  */

--- a/stylustheme.css
+++ b/stylustheme.css
@@ -610,6 +610,11 @@
     }
     /*robux patch      */
     /* Some moved to image patch section */
+        
+    /* Remove nav-credit display */
+    .nav-credit {
+        display: var(--creditVis) !important;
+    }
 
     .light-theme .icon-default-economy-28x28, .light-theme .icon-robux-28x28, .light-theme .icon-robux-gold-28x28, .light-theme .icon-robux-white {
     /*     background-image: url(https://svgur.com/i/GuZ.svg); */

--- a/unreleasedChanges.md
+++ b/unreleasedChanges.md
@@ -28,6 +28,7 @@ Standard releases can be found at [ROBLOX2016stylus/releases](https://github.com
 - [Home] Made dark-mode wide game tiles look better.
 - [Home] Made dark-mode friends list header look better. 
 - [Search] Fix player and vote count positioning on featured games when searching.
+- [Settings] Optional visibility for credit
 
 ### Find a bug?
 


### PR DESCRIPTION
This PR adds the following two features/fixes:
- Adds a creditVis option to disable/enable credit visibility in the navbar
- Fixes the credit icon on dark mode

Solves #51 